### PR TITLE
Upgrade database version to 2.1.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: ghcr.io/neicnordic/sda-db:v2.1.1
+    image: ghcr.io/neicnordic/sda-db:v2.1.5
     networks:
       - secure
     restart: always


### PR DESCRIPTION
Upgrade the database version to 2.1.5 in order to work with the new grants introduced in sda-db version 2.1.4.

Note: The change makes it possible to work with the sda-download work in progress, that adds s3 endpoints