### PR TITLE
Add `oidc` healthcheck and let `download` depend on that instead of "started" service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         pip install --upgrade pip
         pip install aiohttp Authlib
         python -u /oidc.py &
-        echo "$!" >/tmp/server.pid
+        echo "$$!" >/tmp/server.pid
         wait
     container_name: oidc
     depends_on:
@@ -56,7 +56,7 @@ services:
           "CMD",
           "sh",
           "-c",
-          "kill -0 $(cat /tmp/server.pid)"
+          "kill -0 $$(cat /tmp/server.pid)"
         ]
       interval: 5s
       timeout: 20s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,9 @@ services:
       - |
         pip install --upgrade pip
         pip install aiohttp Authlib
-        python -u /oidc.py
+        python -u /oidc.py &
+        echo "$!" >/tmp/server.pid
+        wait
     container_name: oidc
     depends_on:
       credentials:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,17 @@ services:
     depends_on:
       credentials:
         condition: service_completed_successfully
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "sh",
+          "-c",
+          "kill -0 $(cat /tmp/server.pid)"
+        ]
+      interval: 5s
+      timeout: 20s
+      retries: 3
     image: python:3.10-slim
     networks:
       - public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
       credentials:
         condition: service_completed_successfully
       oidc:
-        condition: service_started
+        condition: service_healthy
       postgres:
         condition: service_healthy
       s3:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,8 +59,8 @@ services:
           "kill -0 $$(cat /tmp/server.pid)"
         ]
       interval: 5s
-      timeout: 20s
-      retries: 3
+      timeout: 10s
+      retries: 20
     image: python:3.10-slim
     networks:
       - public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       test:
         [
           "CMD",
-          "bash",
+          "sh",
           "-c",
           "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms"
         ]


### PR DESCRIPTION
Closes #12 by adding simple health check to the `oidc` service and letting the `download` service depend on that, thereby delaying the start of the latter service so that it can start properly on its first try.