### PR TITLE
Increase rabbitmq and postgres healthcheck retries before failing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
         ]
       interval: 5s
       timeout: 20s
-      retries: 3
+      retries: 20
     image: ghcr.io/neicnordic/sda-mq:v1.4.28
     networks:
       - secure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
         ]
       interval: 5s
       timeout: 20s
-      retries: 3
+      retries: 20
     image: ghcr.io/neicnordic/sda-db:v2.1.5
     networks:
       - secure


### PR DESCRIPTION
The rabbit mq and postgres fail sometimes due to the time it takes to turn healthy. The PR increases the number of retries to 20, in accordance to the oidc.