### PR TITLE
Feature/htsget support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,7 @@ services:
     environment:
       - DB_PASSWORD=download
       - DB_USER=download
-    image: ghcr.io/neicnordic/sda-download:v1.8.7
+    image: harbor.nbis.se/gdi/sda-download:dev
     networks:
       - public
       - secure

--- a/scripts/certs/ssl.cnf
+++ b/scripts/certs/ssl.cnf
@@ -91,7 +91,7 @@ subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer:always
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
-subjectAltName = DNS:localhost,DNS:mq,DNS:db,DNS:doa,DNS:download,DNS:oidc,IP:127.0.0.1
+subjectAltName = DNS:localhost,DNS:mq,DNS:db,DNS:doa,DNS:download,DNS:server,DNS:oidc,IP:127.0.0.1
 
 [ crl_ext ]
 # Extension for CRLs (`man x509v3_config`).


### PR DESCRIPTION
Changes the version of sda-download to the one with support of s3 endpoints (currently under review in sda-download repository)
Updates the ssl configuration to include the htsget server as DNS