### PR TITLE
Feature/add sda auth to compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,96 @@
 # starter-kit-storage-and-interfaces
 
-To boot strap all of this simply run:
+There exist two compose files at the root of the repo. Details on how to use them are provided below.
 
-```cmd
+## Starting the full stack with LS-AAI-mock
+
+To bootstrap the *full stack* of `storage-and-interfaces` services use
+the file `docker-compose.yml`. Note that this requires a running [`LS-AAI-mock`](https://github.com/GenomicDataInfrastructure/starter-kit-lsaai-mock) service. To configure the LS-AAI-mock service follow the instructions below.
+
+Add the following line to `/etc/hosts` file:
+
+```
+127.0.0.1 aai-mock
+```
+
+First clone the [startet-kit-lsaai-mock](https://github.com/GenomicDataInfrastructure/starter-kit-lsaai-mock) repo.
+
+Under its root folder, change the first two lines of the file `configuration/aai-mock/application.properties` to:
+
+```
+main.oidc.issuer.url=http://aai-mock:8080/oidc/
+web.baseURL=https://aai-mock:8080/oidc
+```
+
+and then add the `sda-auth` client by creating a file `configuration/aai-mock/clients/client1.yaml` with the following contents:
+
+```ini
+client-name: "auth"
+client-id: "XC56EL11xx"
+client-secret: "wHPVQaYXmdDHg"
+redirect-uris: ["https://localhost:8085/elixir/login"]
+token-endpoint-auth-method: "client_secret_basic"
+scope: ["openid", "profile", "email", "ga4gh_passport_v1"]
+grant-types: ["authorization_code"]
+post-logout-redirect-uris: ["https://auth:8085/elixir/login"]
+```
+
+Now that everything should be configured properly, return to the root folder of the `starter-kit-strorage-and-interfaces` and run:
+
+```shell
 docker compose up -d
 ```
 
-For demonstration purpose with an example dataset use the following command:
+Lastly, *while the `storage-and-interfaces` stack is being deployed*, return to the `starter-kit-lsaai-mock` root folder and run:
 
-```cmd
-docker compose --profile demo up -d
+```shell
+docker compose up -d
 ```
 
-The files imported by the data loading script come from here: `https://github.com/ga4gh/htsget-refserver/tree/main/data/gcp/gatk-test-data/wgs_bam`
+Note that the above two commands need to be run in that specific order because the `LS-AAI-mock` service expects to connect to an external network `my-app-network` which is created by the `storage-and-interfaces`' compose file.
 
-## Download unencrypted files directly
+## Starting the stack in standalone demo mode
+
+The file `docker-compose-demo.yml` is used to start the `storage-and-interfaces` services in *demo* mode with an example dataset preloaded and ingested to the sensitive data archive when the deployment is done. This comes with its own python implementation of a mock-oidc in place of LS-AAI and can be run as standalone for demonstration purposes.
+
+The files imported by the data loading script come from here: https://github.com/ga4gh/htsget-refserver/tree/main/data/gcp/gatk-test-data/wgs_bam
+
+To deploy use the following command:
+
+```shell
+docker compose -f docker-compose-demo.yml up -d
+```
+
+After deployment is done, follow the following instructions to test that the demo worked as expected.
+
+### **Download unencrypted files directly**
 
 ### Get token for downloading data
 
-There are 3 tokens available, the first has access to a dataset at this site, the second one is empty and the third doesn't have access to this site.
+For the purpose of the demo stack, tokens can be issued by the included `oidc` service and be used to authorize calls to the `download` service's API. The `oidc` is a simple Python implementation that mimics the basic OIDC functionality of LS-AAI. It does not require user authentication and serves a valid token through its `/token` endpoint:
 
-```cmd
+```shell
 token=$(curl -s -k https://localhost:8080/tokens | jq -r '.[0]')
 ```
 
+This token is created upon deployment. See `scripts/make_credentials.sh` for more details. Note that the API returns a list of tokens where the first element is the token of interest, and the rest are tokens for [testing  `sda-download`](https://github.com/neicnordic/sda-download/blob/main/dev_utils/README.md#get-a-token).
+
 ### List datasets
 
-```cmd
+```shell
 curl -s -H "Authorization: Bearer $token" http://localhost:8443/metadata/datasets | jq .
 ```
 
 ### List files in a dataset
 
-```cmd
+```shell
 datasetID=$(curl -s -H "Authorization: Bearer $token" http://localhost:8443/metadata/datasets | jq -r .'[0]')
 curl -s -H "Authorization: Bearer $token" "http://localhost:8443/metadata/datasets/$datasetID/files" | jq .
 ```
 
 ### Download a specific file
 
-```cmd
+```shell
 fileID=$(curl -s -H "Authorization: Bearer $token" "http://localhost:8443/metadata/datasets/$datasetID/files" | jq -r '.[0].fileId')
 filename=$(curl -s -H "Authorization: Bearer $token" "http://localhost:8443/metadata/datasets/$datasetID/files" | jq -r '.[0].displayFileName' | cut -d '.' -f 1,2 )
 curl -s -H "Authorization: Bearer $token" http://localhost:8443/files/$fileID -o "$filename"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To deploy use the following command:
 docker compose -f docker-compose-demo.yml up -d
 ```
 
-After deployment is done, follow the following instructions to test that the demo worked as expected.
+After deployment is done, follow the instructions below to test that the demo worked as expected.
 
 ### **Download unencrypted files directly**
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The files imported by the data loading script come from here: `https://github.co
 There are 3 tokens available, the first has access to a dataset at this site, the second one is empty and the third doesn't have access to this site.
 
 ```cmd
-token=$(curl -s -k https://localhost:8081/tokens | jq -r '.[0]')
+token=$(curl -s -k https://localhost:8080/tokens | jq -r '.[0]')
 ```
 
 ### List datasets

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The files imported by the data loading script come from here: `https://github.co
 There are 3 tokens available, the first has access to a dataset at this site, the second one is empty and the third doesn't have access to this site.
 
 ```cmd
-token=$(curl -s -k https://localhost:8080/tokens | jq -r '.[0]')
+token=$(curl -s -k https://localhost:8081/tokens | jq -r '.[0]')
 ```
 
 ### List datasets

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,7 +61,7 @@ oidc:
   # oidc configuration API must have values for "userinfo_endpoint" and "jwks_uri"
   cacert: "/shared/cert/ca.crt"
   configuration:
-    url: "https://oidc:8080/.well-known/openid-configuration"
+    url: "https://oidc:8081/.well-known/openid-configuration"
   trusted:
     iss: "/iss.json"
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,7 +61,7 @@ oidc:
   # oidc configuration API must have values for "userinfo_endpoint" and "jwks_uri"
   cacert: "/shared/cert/ca.crt"
   configuration:
-    url: "https://oidc:8080/.well-known/openid-configuration"
+    url: "http://aai-mock:8080/oidc/.well-known/openid-configuration"
   trusted:
     iss: "/iss.json"
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,7 +61,7 @@ oidc:
   # oidc configuration API must have values for "userinfo_endpoint" and "jwks_uri"
   cacert: "/shared/cert/ca.crt"
   configuration:
-    url: "https://oidc:8081/.well-known/openid-configuration"
+    url: "https://oidc:8080/.well-known/openid-configuration"
   trusted:
     iss: "/iss.json"
 

--- a/config/iss.json
+++ b/config/iss.json
@@ -1,7 +1,11 @@
 [
     {
-        "iss": "https://oidc:8080/",
-        "jku": "https://oidc:8080/jwk"
+        "iss": "https://oidc:8081/",
+        "jku": "https://oidc:8081/jwk"
+    },
+    {
+        "iss": "http://aai-mock:8080/oidc/",
+        "jku": "http://aai-mock:8080/oidc/jwk"
     },
     {
         "iss": "http://demo1.example",

--- a/config/iss.json
+++ b/config/iss.json
@@ -1,7 +1,7 @@
 [
     {
-        "iss": "https://oidc:8081/",
-        "jku": "https://oidc:8081/jwk"
+        "iss": "https://oidc:8080/",
+        "jku": "https://oidc:8080/jwk"
     },
     {
         "iss": "http://aai-mock:8080/oidc/",

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -1,0 +1,111 @@
+services:
+  credentials:
+    extends:
+      file: docker-compose.yml
+      service: credentials
+
+  data_loader:
+    container_name: data_loader
+    command:
+      - "/bin/sh"
+      - "/load_data.sh"
+    depends_on:
+      s3inbox:
+        condition: service_started
+    image: python:3.10-alpine
+    networks:
+      - secure
+    volumes:
+      - ./scripts/load_data.sh:/load_data.sh
+      - shared:/shared
+
+  ### OIDC (LS-AAI in  a box)
+  oidc:
+    command:
+      - /bin/sh
+      - -c
+      - |
+        pip install --upgrade pip
+        pip install aiohttp Authlib
+        python -u /oidc.py &
+        echo "$$!" >/tmp/server.pid
+        wait
+    container_name: oidc
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+    healthcheck:
+      test: [ "CMD", "sh", "-c", "kill -0 $$(cat /tmp/server.pid)" ]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+    image: python:3.10-slim
+    networks:
+      - public
+    ports:
+      - "8080:8080"
+    restart: always
+    volumes:
+      - ./servers/oidc.py:/oidc.py
+      - shared:/shared
+  ###
+
+  rabbitmq:
+    extends:
+      file: docker-compose.yml
+      service: rabbitmq
+
+  postgres:
+    extends:
+      file: docker-compose.yml
+      service: postgres
+
+  s3:
+    extends:
+      file: docker-compose.yml
+      service: s3
+
+  ## data ingest pipeline
+  download:
+    extends:
+      file: docker-compose.yml
+      service: download
+    depends_on:
+      oidc:
+        condition: service_healthy
+    environment:
+      - OIDC_CONFIGURATION_URL=https://oidc:8080/.well-known/openid-configuration
+
+  finalize:
+    extends:
+      file: docker-compose.yml
+      service: finalize
+
+  ingest:
+    extends:
+      file: docker-compose.yml
+      service: ingest
+
+  mapper:
+    extends:
+      file: docker-compose.yml
+      service: mapper
+
+  verify:
+    extends:
+      file: docker-compose.yml
+      service: verify
+
+  s3inbox:
+    extends:
+      file: docker-compose.yml
+      service: s3inbox
+
+volumes:
+  pgdata:
+  shared:
+  s3data:
+
+networks:
+  public:
+  secure:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,13 +51,7 @@ services:
       credentials:
         condition: service_completed_successfully
     healthcheck:
-      test:
-        [
-          "CMD",
-          "sh",
-          "-c",
-          "kill -0 $$(cat /tmp/server.pid)"
-        ]
+      test: [ "CMD", "sh", "-c", "kill -0 $$(cat /tmp/server.pid)" ]
       interval: 5s
       timeout: 10s
       retries: 20
@@ -71,6 +65,35 @@ services:
       - ./servers/oidc.py:/oidc.py
       - shared:/shared
 ###
+
+  auth:
+    container_name: auth
+    profiles:
+      - auth
+    image: ghcr.io/neicnordic/sda-auth:v0.7.3
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+    environment:
+      - ELIXIR_ID=XC56EL11xx
+      - ELIXIR_PROVIDER=http://aai-mock:8080/oidc/
+      - ELIXIR_SECRET=wHPVQaYXmdDHg
+      - ELIXIR_JWKPATH=jwk
+      - ELIXIR_REDIRECTURL=http://localhost:8085/elixir/login
+      - LOG_LEVEL=info
+      - S3INBOX=localhost:8000
+      - JWTISSUER=http://auth:8085
+      - JWTPRIVATEKEY=shared/keys/jwt.key
+      - JWTSIGNATUREALG=ES256
+      - RESIGNJWT=False
+    volumes:
+      - shared:/shared
+    ports:
+      - 8085:8080
+    networks:
+      - public
+      - my-app-network
+    restart: always
 
   rabbitmq:
     container_name: rabbitmq
@@ -325,3 +348,6 @@ volumes:
 networks:
   public:
   secure:
+  # required for allowing auth to connect to ls-aai-mock
+  my-app-network:
+    name: my-app-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     networks:
       - public
     ports:
-      - "8080:8080"
+      - "8081:8081"
     restart: always
     volumes:
       - ./servers/oidc.py:/oidc.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     networks:
       - public
     ports:
-      - "8081:8081"
+      - "8080:8080"
     restart: always
     volumes:
       - ./servers/oidc.py:/oidc.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# Services auth, download and s3inbox in this file will try to connect to the ls-aai-mock service.
+# Remember to start the later while this stack is being deployed. See documentation for more details.
+
 services:
   credentials:
     container_name: credentials
@@ -18,59 +21,9 @@ services:
       - ./scripts:/scripts
       - shared:/shared
 
-  data_loader:
-    container_name: data_loader
-    command:
-      - "/bin/sh"
-      - "/load_data.sh"
-    depends_on:
-      s3inbox:
-        condition: service_started
-    image: python:3.10-alpine
-    networks:
-      - secure
-    profiles:
-      - demo
-    volumes:
-      - ./scripts/load_data.sh:/load_data.sh
-      - shared:/shared
-
-### OIDC (LS-AAI in  a box)
-  oidc:
-    command:
-      - /bin/sh
-      - -c
-      - |
-        pip install --upgrade pip
-        pip install aiohttp Authlib
-        python -u /oidc.py &
-        echo "$$!" >/tmp/server.pid
-        wait
-    container_name: oidc
-    depends_on:
-      credentials:
-        condition: service_completed_successfully
-    healthcheck:
-      test: [ "CMD", "sh", "-c", "kill -0 $$(cat /tmp/server.pid)" ]
-      interval: 5s
-      timeout: 10s
-      retries: 20
-    image: python:3.10-slim
-    networks:
-      - public
-    ports:
-      - "8080:8080"
-    restart: always
-    volumes:
-      - ./servers/oidc.py:/oidc.py
-      - shared:/shared
-###
-
   auth:
     container_name: auth
-    profiles:
-      - auth
-    image: ghcr.io/neicnordic/sda-auth:v0.7.3
+    image: ghcr.io/neicnordic/sda-auth:v0.7.7
     depends_on:
       credentials:
         condition: service_completed_successfully
@@ -184,8 +137,6 @@ services:
     depends_on:
       credentials:
         condition: service_completed_successfully
-      oidc:
-        condition: service_healthy
       postgres:
         condition: service_healthy
       s3:
@@ -197,6 +148,7 @@ services:
     networks:
       - public
       - secure
+      - my-app-network
     ports:
       - 8443:8443
     restart: always
@@ -331,10 +283,12 @@ services:
       - DB_PASSWORD=inbox
       - DB_USER=inbox
       - SERVER_CONFFILE=/config.yaml
+      - SERVER_JWTPUBKEYURL=http://aai-mock:8080/oidc/jwk
     image: ghcr.io/neicnordic/sda-s3proxy:v0.2.19
     networks:
       - public
       - secure
+      - my-app-network
     ports:
       - "8000:8000"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,12 +79,14 @@ services:
       - ELIXIR_PROVIDER=http://aai-mock:8080/oidc/
       - ELIXIR_SECRET=wHPVQaYXmdDHg
       - ELIXIR_JWKPATH=jwk
-      - ELIXIR_REDIRECTURL=http://localhost:8085/elixir/login
+      - ELIXIR_REDIRECTURL=https://localhost:8085/elixir/login
       - LOG_LEVEL=info
       - S3INBOX=localhost:8000
       - JWTISSUER=http://auth:8085
       - JWTPRIVATEKEY=shared/keys/jwt.key
       - JWTSIGNATUREALG=ES256
+      - SERVER_CERT=shared/cert/server.crt
+      - SERVER_KEY=shared/cert/auth.key
       - RESIGNJWT=False
     volumes:
       - shared:/shared

--- a/scripts/certs/make_certs.sh
+++ b/scripts/certs/make_certs.sh
@@ -55,5 +55,9 @@ cp "$out_dir"/server.key "$out_dir"/download.key
 chown 0:65534 "$out_dir"/download.key
 chmod 640 "$out_dir"/download.key
 
+cp "$out_dir"/server.key "$out_dir"/auth.key
+chown 0:65534 "$out_dir"/auth.key
+chmod 640 "$out_dir"/auth.key
+
 chown 0:65534 "$out_dir"/client.*
 chmod 640 "$out_dir"/client.*

--- a/servers/oidc.py
+++ b/servers/oidc.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 HTTP_PROTOCOL = "http"
-OIDC_PORT = 8081
+OIDC_PORT = 8080
 
 def _set_ssl() -> Union[ssl.SSLContext, None]:
     global HTTP_PROTOCOL

--- a/servers/oidc.py
+++ b/servers/oidc.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 HTTP_PROTOCOL = "http"
-
+OIDC_PORT = 8081
 
 def _set_ssl() -> Union[ssl.SSLContext, None]:
     global HTTP_PROTOCOL
@@ -44,7 +44,7 @@ def _generate_token() -> Tuple:
     # See available claims here: http://www.iana.org/assignments/jwt/jwt.xhtml
     # the important claim is the "authorities"
     header = {
-        "jku": f"{HTTP_PROTOCOL}://oidc:8080/jwk",
+        "jku": f"{HTTP_PROTOCOL}://oidc:{OIDC_PORT}/jwk",
         "kid": "EC1",
         "alg": "ES256",
         "typ": "JWT",
@@ -54,7 +54,7 @@ def _generate_token() -> Tuple:
         "aud": ["aud1", "aud2"],
         "azp": "azp",
         "scope": "openid ga4gh_passport_v1",
-        "iss": "https://oidc:8080/",
+        "iss": f"https://oidc:{OIDC_PORT}/",
         "exp": 9999999999,
         "iat": 1561621913,
         "jti": "6ad7aa42-3e9c-4833-bd16-765cb80c2102",
@@ -64,21 +64,21 @@ def _generate_token() -> Tuple:
         "aud": ["aud2", "aud3"],
         "azp": "azp",
         "scope": "openid ga4gh_passport_v1",
-        "iss": "https://oidc:8080/",
+        "iss": f"https://oidc:{OIDC_PORT}/",
         "exp": 9999999999,
         "iat": 1561621913,
         "jti": "6ad7aa42-3e9c-4833-bd16-765cb80c2102",
     }
     empty_payload = {
         "sub": "requester@demo.org",
-        "iss": "https://oidc:8080/",
+        "iss": f"https://oidc:{OIDC_PORT}/",
         "exp": 99999999999,
         "iat": 1547794655,
         "jti": "6ad7aa42-3e9c-4833-bd16-765cb80c2102",
     }
     # Craft passports
     passport_terms = {
-        "iss": "https://oidc:8080/",
+        "iss": f"https://oidc:{OIDC_PORT}/",
         "sub": "requester@demo.org",
         "ga4gh_visa_v1": {
             "type": "AcceptedTermsAndPolicies",
@@ -93,7 +93,7 @@ def _generate_token() -> Tuple:
     }
     # passport for dataset permissions 1
     passport_dataset1 = {
-        "iss": "https://oidc:8080/",
+        "iss": f"https://oidc:{OIDC_PORT}/",
         "sub": "requester@demo.org",
         "ga4gh_visa_v1": {
             "type": "ControlledAccessGrants",
@@ -157,12 +157,12 @@ def _generate_token() -> Tuple:
 async def fixed_response(request: web.Request) -> web.Response:
     global HTTP_PROTOCOL
     WELL_KNOWN = {
-        "issuer": f"{HTTP_PROTOCOL}://oidc:8080",
-        "authorization_endpoint": f"{HTTP_PROTOCOL}://oidc:8080/authorize",
-        "registration_endpoint": f"{HTTP_PROTOCOL}://oidc:8080/register",
-        "token_endpoint": f"{HTTP_PROTOCOL}://oidc:8080/token",
-        "userinfo_endpoint": f"{HTTP_PROTOCOL}://oidc:8080/userinfo",
-        "jwks_uri": f"{HTTP_PROTOCOL}://oidc:8080/jwk",
+        "issuer": f"{HTTP_PROTOCOL}://oidc:{OIDC_PORT}",
+        "authorization_endpoint": f"{HTTP_PROTOCOL}://oidc:{OIDC_PORT}/authorize",
+        "registration_endpoint": f"{HTTP_PROTOCOL}://oidc:{OIDC_PORT}/register",
+        "token_endpoint": f"{HTTP_PROTOCOL}://oidc:{OIDC_PORT}/token",
+        "userinfo_endpoint": f"{HTTP_PROTOCOL}://oidc:{OIDC_PORT}/userinfo",
+        "jwks_uri": f"{HTTP_PROTOCOL}://oidc:{OIDC_PORT}/jwk",
         "response_types_supported": [
             "code",
             "id_token",
@@ -306,4 +306,4 @@ def init() -> web.Application:
 if __name__ == "__main__":
     ssl_context = _set_ssl()
     DATA = _generate_token()
-    web.run_app(init(), port=8080, ssl_context=ssl_context)
+    web.run_app(init(), port=OIDC_PORT, ssl_context=ssl_context)


### PR DESCRIPTION
This PR adds the `sda-auth` service to the storage-and-interfaces deployment stack. The service runs with TLS enabled and in the current form of the compose file, `sda-auth` is configured to work out-of-the-box with the [LS-AAI-mock](https://github.com/GenomicDataInfrastructure/starter-kit-lsaai-mock) service for demonstration purposes. Consequently `sda-auth` requires that the later service is started so that it can connect to it. Instructions for this purpose are added in the README file.

Following the PR discussion, the demo profile is now split off to its own `docker-compose-demo.yml` which uses `oidc.py` for issuing tokens and therefore can be run as standalone without any dependency to external services like LS-AAI.

On the other hand, the `docker-compose.yml` file now has the full storage-and-interfaces-stack with all services (`auth`, 's3inbox', `download`) working with LS-AAI-mock as their OIDC service.

Additional changes introduced:

- added `my-app-network` which `ls-aai-mock` expects to attach to as an external network
- added instructions for deployment alongside the `LS-AAI-mock` service in the README file and reworked the structure of the document to reflect the two different compose setups

Closes #16