### PR TITLE
Allow the `accession` sub-command to assign multiple IDs

### DIFF
--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -528,6 +528,11 @@ usage_general () {
 	                the utility will be located using your "PATH"
 	                variable, as is done for any ordinary utility.
 
+	    MQ_CREDENTIALS, MQ_URL, SDA_CONFIG, SDA_KEY
+	                These variables corresponds to the similarly
+	                named global options.  The command line options
+	                will override the environment variables.
+
 	USAGE_GENERAL
 }
 

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -164,7 +164,8 @@ curl () {
 		--request POST \
 		--user "$MQ_CREDENTIALS" \
 		--header "Content-Type: application/json" \
-		"$@"
+		"$@" |
+	jq 'if type == "object" and has("error") then halt_error(1) else . end'
 }
 
 access_key () {

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -361,21 +361,34 @@ accession () {
 	# We expect either exactly two arguments here (one accession
 	# ID and one filename), or three or more arguments (one
 	# format string, an inital counter value, and one or several
-	# pathnames).  If two arguments are given, the filename argument
-	# should not end in a slash.
+	# pathnames).
 	#
 	err=false
 	if [ "$#" -eq 2 ]; then
-		if case $2 in (*/) true;; (*) false; esac; then
-			err=true
-		else
-			accession_id=$1
-			shift
-		fi
+		accession_id=$1
+		shift
+
+		# The filename must not end in "/".
+		case $1 in
+			*/)
+				err=true
+		esac
 	elif [ "$#" -ge 3 ]; then
 		accession_format=$1
 		counter=$2
 		shift 2
+
+		# The format string must contain exactly one "%".
+		case $accession_format in
+			*%*%*)
+				err=true
+				;;
+			*%*)
+				# Do nothing.
+				;;
+			*)
+				err=true
+		esac
 	else
 		err=true
 	fi

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -158,7 +158,9 @@ upload () {
 curl () {
 	# Helper function that makes curl calls a bit shorter.
 
-	command curl --silent \
+	command curl \
+		--silent \
+		--show-error \
 		--request POST \
 		--user "$MQ_CREDENTIALS" \
 		--header "Content-Type: application/json" \

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -21,6 +21,9 @@ SDA_KEY=${SDA_KEY-crypt4gh_key.pub}			# --sda-key pathname
 # not set, the tool will be picked up from "$PATH" as usual.
 SDA_CLI=${SDA_CLI-sda-cli}	# --sda-cli pathname
 
+# There is also S3_ACCESS_KEY (--s3-access-key), but since its value
+# depend on the final value of "$SDA_CONFIG", we can't set it here.
+
 encrypt () {
 	# Encrypt the given files using "sda-cli".
 	#
@@ -168,14 +171,6 @@ curl () {
 	jq 'if type == "object" and has("error") then halt_error(1) else . end'
 }
 
-access_key () {
-	# Parses the S3 configuration file and outputs the access key.
-
-	sed	-e '/^access_key[[:blank:]]*=[[:blank:]]*/!d' \
-		-e 's///' -e 's/[[:blank:]]*$//' -e 'q' \
-		"$SDA_CONFIG"
-}
-
 publish () {
 	# Will read base64-encoded messages from standard input, one
 	# per line, decode each message and publish it.  Any output is
@@ -254,15 +249,13 @@ get_messages () {
 	queue=$1
 	shift
 
-	access_key=$(access_key)
-
 	for pathname do
 		shift
 
 		# Add the user bucket name to the start of the given
 		# pathname.
 		#
-		pathname=$access_key/$pathname
+		pathname=$S3_ACCESS_KEY/$pathname
 
 		# Add ".c4gh" to the end of the pathname if the pathname
 		# doesn't already have it and if it's not a directory
@@ -313,12 +306,10 @@ get_filenames () {
 
 	queue=$1
 
-	access_key=$(access_key)
-
 	curl --data \
 		'{"count":-1,"encoding":"base64","ackmode":"ack_requeue_true"}' \
 		"$url_queues/$queue/get" |
-	jq -r --arg access_key "$access_key" '
+	jq -r --arg access_key "$S3_ACCESS_KEY" '
 		map(.payload | @base64d | fromjson |
 		select(.filepath | startswith($access_key + "/")).filepath |
 			sub(".*?/"; "")) | unique[]'
@@ -514,6 +505,7 @@ usage_general () {
 	    --sda-cli pathname		Path for "sda-cli" executable	Currently: $SDA_CLI
 	    --sda-config pathname	SDA S3 configuration file	Currently: $SDA_CONFIG
 	    --sda-key pathname		SDA CRYPT4GH public key file	Currently: $SDA_KEY
+	    --s3-access-key		Override S3 access key		Currently: $S3_ACCESS_KEY
 
 	Specific synopsis:
 	    $myself help
@@ -739,6 +731,9 @@ while true; do
 		--sda-key)
 			SDA_KEY=$2
 			;;
+		--s3-access-key)
+			S3_ACCESS_KEY=$2
+			;;
 		-*)
 			usage >&2
 			exit 1
@@ -752,6 +747,15 @@ done
 url_api=$MQ_URL/api
 url_exchanges=$url_api/exchanges/$MQ_EXCHANGE_PREFIX
 url_queues=$url_api/queues/$MQ_QUEUE_PREFIX
+
+# Handle S3_ACCESS_KEY.
+if [ "${S3_ACCESS_KEY+set}" != set ]; then
+	S3_ACCESS_KEY=$(
+		sed	-e '/^access_key[[:blank:]]*=[[:blank:]]*/!d' \
+			-e 's///' -e 's/[[:blank:]]*$//' -e 'q' \
+			"$SDA_CONFIG"
+	)
+fi
 
 # Handle sub-commands.
 case ${1-} in

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -505,7 +505,7 @@ usage_general () {
 	    --sda-cli pathname		Path for "sda-cli" executable	Currently: $SDA_CLI
 	    --sda-config pathname	SDA S3 configuration file	Currently: $SDA_CONFIG
 	    --sda-key pathname		SDA CRYPT4GH public key file	Currently: $SDA_KEY
-	    --s3-access-key		Override S3 access key		Currently: $S3_ACCESS_KEY
+	    --s3-access-key		Override S3 access key		Currently: ${S3_ACCESS_KEY-<unset>}
 
 	Specific synopsis:
 	    $myself help
@@ -749,7 +749,7 @@ url_exchanges=$url_api/exchanges/$MQ_EXCHANGE_PREFIX
 url_queues=$url_api/queues/$MQ_QUEUE_PREFIX
 
 # Handle S3_ACCESS_KEY.
-if [ "${S3_ACCESS_KEY+set}" != set ]; then
+if [ "${S3_ACCESS_KEY+set}" != set ] && [ -f "$SDA_CONFIG" ]; then
 	S3_ACCESS_KEY=$(
 		sed	-e '/^access_key[[:blank:]]*=[[:blank:]]*/!d' \
 			-e 's///' -e 's/[[:blank:]]*$//' -e 'q' \
@@ -760,6 +760,9 @@ fi
 # Handle sub-commands.
 case ${1-} in
 	upload|ingest|accession|dataset)
+		# Ensure that S3_ACCESS_KEY is actually set before
+		# trying to use it, or bail out here.
+		: ${S3_ACCESS_KEY?Missing S3 access key}
 		"$@"
 		;;
 	help)

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -408,6 +408,7 @@ accession () {
 		# with "$counter" to calculate the new accession ID.
 		# Otherwise just use "$accession_id" directly.
 		if [ "${accession_format+set}" = set ]; then
+			# shellcheck disable=SC2059
 			accession_id=$( printf "$accession_format" "$counter" )
 			counter=$(( counter + 1 ))
 		fi

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -417,6 +417,7 @@ accession () {
 		if [ "${accession_format+set}" = set ]; then
 			# shellcheck disable=SC2059
 			accession_id=$( printf "$accession_format" "$counter" )
+			printf 'Accession ID #%d: %s\n' "$counter" "$accession_id" >&2
 			counter=$(( counter + 1 ))
 		fi
 

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -638,6 +638,11 @@ usage_accession () {
 	integer counter.  The accession IDs will be assigned to the
 	mentioned files in ascending integer sequence.
 
+	NOTE:   This script does not care about the format of the
+	NOTE:   accession IDs or whether the assigned accession IDs
+	NOTE:   are unique etc.  It is up to the user to ensure that
+	NOTE:   the correct accession IDs are assigned.
+
 	Filenames do not have to be given with the trailing ".c4gh"
 	filename suffix.
 

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -347,7 +347,8 @@ ingest () {
 }
 
 accession () {
-	# Assign accession IDs to ingested files.
+	# Assign an accession ID to a single ingested file, or assign
+	# multiple accession IDs to several files.
 
 	# If no arguments are given, list the filenames that may be
 	# processed, then return immediately.
@@ -357,39 +358,61 @@ accession () {
 		return
 	fi
 
-	# We expect exactly two arguments here; one accession ID and one
-	# filename.  The filename should not end in a slash.
+	# We expect either exactly two arguments here (one accession
+	# ID and one filename), or three or more arguments (one
+	# format string, an inital counter value, and one or several
+	# pathnames).  If two arguments are given, the filename argument
+	# should not end in a slash.
 	#
-	if	[ "$#" -ne 2 ] ||
-		case $2 in (*/) true;; (*) false; esac
-	then
+	err=false
+	if [ "$#" -eq 2 ]; then
+		if case $2 in (*/) true;; (*) false; esac; then
+			err=true
+		else
+			accession_id=$1
+			shift
+		fi
+	elif [ "$#" -ge 3 ]; then
+		accession_format=$1
+		counter=$2
+		shift 2
+	else
+		err=true
+	fi
+
+	if "$err"; then
 		usage_accession >&2
 		return 1
 	fi
 
-	accession_id=$1
-	shift
-
-	# Get the message that we want from the "verified" queue (there
-	# will be at most one message as they are deduplicated based
-	# on the file path, and we're only querying using a single
-	# filename), then rewrite them into accession messages and
-	# publish them.
+	# Get the messages that we want from the "verified" queue,
+	# figure out a new accession ID (if we're asked to do so),
+	# rewrite them into accession messages, and publish them.
 	#
 	get_messages verified "$@" |
-	jq -r -R --arg accession_id "$accession_id" '
-		@base64d | fromjson |
-		.payload |= (
+	while IFS= read -r message; do
+		# If "$accession_format" is set, then we should use that
+		# with "$counter" to calculate the new accession ID.
+		# Otherwise just use "$accession_id" directly.
+		if [ "${accession_format+set}" = set ]; then
+			accession_id=$( printf "$accession_format" "$counter" )
+			counter=$(( counter + 1 ))
+		fi
+
+		printf '%s\n' "$message" |
+		jq -r -R --arg accession_id "$accession_id" '
 			@base64d | fromjson |
-			.type = "accession" |
-			.accession_id = $accession_id |
-			del(.filesize,.operation) |
-			@base64
-		) |
-		.routing_key = "accessionIDs" |
-		del(.payload_bytes) |
-		@base64' |
-	publish
+			.payload |= (
+				@base64d | fromjson |
+				.type = "accession" |
+				.accession_id = $accession_id |
+				del(.filesize,.operation) |
+				@base64
+			) |
+			.routing_key = "accessionIDs" |
+			del(.payload_bytes) |
+			@base64'
+	done | publish
 }
 
 dataset () {
@@ -478,6 +501,7 @@ usage_general () {
 	    $myself help ingest
 
 	    $myself [...] accession accessionID pathname
+	    $myself [...] accession format start pathname [pathname...]
 	    $myself [...] accession
 	    $myself help accession
 
@@ -578,8 +602,16 @@ usage_ingest () {
 
 usage_accession () {
 	cat <<-USAGE_ACCESSION
-	The "accession" sub-command is used for assigning an accession ID
-	to a single file that has previously been ingested.
+	The "accession" sub-command is used for assigning a specific
+	accession ID to a single file that has previously been ingested,
+	or for assigning a sequence of accession IDs to several ingested
+	files.
+
+        When assigning a sequence of IDs to multiple files, the
+        accession IDs are assigned given a printf format string (which
+        must accept a single integer) and an initial value for an
+        integer counter.  The accession IDs will be assigned to the
+        mentioned files in ascending integer sequence.
 
 	Filenames do not have to be given with the trailing ".c4gh"
 	filename suffix.
@@ -597,6 +629,19 @@ usage_accession () {
 	    $myself accession MYID001 file1
 	    $myself accession MYID002 file2
 	    $myself accession MYID003 file3
+
+	    Assigning accessions to three files, giving them the IDs
+	    "MYID001", "MYID002", and "MYID003":
+
+	    $myself accession 'MYID%03d' 1 file1 file2 file3
+
+	    Assigning accession IDs to all files in or beneath the path
+	    "project/data", starting at 123.  The first two accession
+	    IDs will be "PROJ00000123" and "PROJ00000124".  The ordering
+	    in which accession IDs are assigned will depend on the
+	    ordering of the files in the RabbitMQ queue.
+
+	    $myself accession 'PROJ%08' 123 project/data/
 
 	USAGE_ACCESSION
 }

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -666,7 +666,7 @@ usage_accession () {
 	    in which accession IDs are assigned will depend on the
 	    ordering of the files in the RabbitMQ queue.
 
-	    $myself accession 'PROJ%08' 123 project/data/
+	    $myself accession 'PROJ%08d' 123 project/data/
 
 	USAGE_ACCESSION
 }

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -398,7 +398,7 @@ accession () {
 	fi
 
 	if "$err"; then
-		usage_accession >&2
+		usage accession >&2
 		return 1
 	fi
 
@@ -450,7 +450,7 @@ dataset () {
 	# least one filename.
 	#
 	if [ "$#" -lt 2 ]; then
-		usage_dataset >&2
+		usage dataset >&2
 		return 1
 	fi
 
@@ -751,7 +751,7 @@ case ${1-} in
 		;;
 	help)
 		shift
-		usage "$@"
+		usage "$@" | "${PAGER:-less}"
 		;;
 	*)
 		usage >&2

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -7,10 +7,14 @@ myself=$0
 # Default values for global options.  Values in the environment override
 # these hard-coded defaults, and values set via command line options
 # override these later.
-MQ_CREDENTIALS=${MQ_CREDENTIALS-test:test}	# --mq-credentials user:pass
-MQ_URL=${MQ_URL-http://localhost:15672}		# --mq-url URL
-SDA_CONFIG=${SDA_CONFIG-s3cmd.conf}		# --sda-config pathname
-SDA_KEY=${SDA_KEY-crypt4gh_key.pub}		# --sda-key pathname
+
+MQ_CREDENTIALS=${MQ_CREDENTIALS-test:test}		# --mq-credentials user:pass
+MQ_URL=${MQ_URL-http://localhost:15672}			# --mq-url URL
+MQ_EXCHANGE_PREFIX=${MQ_EXCHANGE_PREFIX-gdi/sda}	# --mq-exchange-prefix some/string
+MQ_QUEUE_PREFIX=${MQ_QUEUE_PREFIX-gdi}			# --mq-queue-prefix string
+
+SDA_CONFIG=${SDA_CONFIG-s3cmd.conf}			# --sda-config pathname
+SDA_KEY=${SDA_KEY-crypt4gh_key.pub}			# --sda-key pathname
 
 # Allow a user to use the environment variable "SDA_CLI" to point
 # directly to the "sda-cli" executable.  If this environment variable is
@@ -501,6 +505,8 @@ usage_general () {
 	Global options:
 	    --mq-credentials user:pass	MQ credentials			Currently: $MQ_CREDENTIALS
 	    --mq-url URL		MQ URL				Currently: $MQ_URL
+	    --mq-exchange-prefix	Prefix for MQ exchanges		Currently: $MQ_EXCHANGE_PREFIX
+	    --mq-queue-prefix		Prefix for MQ queues		Currently: $MQ_QUEUE_PREFIX
 	    --sda-config pathname	SDA S3 configuration file	Currently: $SDA_CONFIG
 	    --sda-key pathname		SDA CRYPT4GH public key file	Currently: $SDA_KEY
 
@@ -528,7 +534,9 @@ usage_general () {
 	                the utility will be located using your "PATH"
 	                variable, as is done for any ordinary utility.
 
-	    MQ_CREDENTIALS, MQ_URL, SDA_CONFIG, SDA_KEY
+	    MQ_CREDENTIALS, MQ_URL,
+	    MQ_EXCHANGE_PREFIX, MQ_QUEUE_PREFIX,
+	    SDA_CONFIG, SDA_KEY
 	                These variables corresponds to the similarly
 	                named global options.  The command line options
 	                will override the environment variables.
@@ -626,11 +634,11 @@ usage_accession () {
 	or for assigning a sequence of accession IDs to several ingested
 	files.
 
-        When assigning a sequence of IDs to multiple files, the
-        accession IDs are assigned given a printf format string (which
-        must accept a single integer) and an initial value for an
-        integer counter.  The accession IDs will be assigned to the
-        mentioned files in ascending integer sequence.
+	When assigning a sequence of IDs to multiple files, the
+	accession IDs are assigned given a printf format string (which
+	must accept a single integer) and an initial value for an
+	integer counter.  The accession IDs will be assigned to the
+	mentioned files in ascending integer sequence.
 
 	Filenames do not have to be given with the trailing ".c4gh"
 	filename suffix.
@@ -709,11 +717,21 @@ while true; do
 		--mq-url)
 			MQ_URL=$2
 			;;
+		--mq-exchange-prefix)
+			MQ_EXCHANGE_PREFIX=$2
+			;;
+		--mq-queue-prefix)
+			MQ_QUEUE_PREFIX=$2
+			;;
 		--sda-config)
 			SDA_CONFIG=$2
 			;;
 		--sda-key)
 			SDA_KEY=$2
+			;;
+		-*)
+			usage >&2
+			exit 1
 			;;
 		*)
 			break
@@ -722,8 +740,8 @@ while true; do
 done
 
 url_api=$MQ_URL/api
-url_exchanges=$url_api/exchanges/gdi/sda
-url_queues=$url_api/queues/gdi
+url_exchanges=$url_api/exchanges/$MQ_EXCHANGE_PREFIX
+url_queues=$url_api/queues/$MQ_QUEUE_PREFIX
 
 # Handle sub-commands.
 case ${1-} in

--- a/scripts/sda-admin
+++ b/scripts/sda-admin
@@ -19,7 +19,7 @@ SDA_KEY=${SDA_KEY-crypt4gh_key.pub}			# --sda-key pathname
 # Allow a user to use the environment variable "SDA_CLI" to point
 # directly to the "sda-cli" executable.  If this environment variable is
 # not set, the tool will be picked up from "$PATH" as usual.
-SDA_CLI=${SDA_CLI-sda-cli}
+SDA_CLI=${SDA_CLI-sda-cli}	# --sda-cli pathname
 
 encrypt () {
 	# Encrypt the given files using "sda-cli".
@@ -507,6 +507,7 @@ usage_general () {
 	    --mq-url URL		MQ URL				Currently: $MQ_URL
 	    --mq-exchange-prefix	Prefix for MQ exchanges		Currently: $MQ_EXCHANGE_PREFIX
 	    --mq-queue-prefix		Prefix for MQ queues		Currently: $MQ_QUEUE_PREFIX
+	    --sda-cli pathname		Path for "sda-cli" executable	Currently: $SDA_CLI
 	    --sda-config pathname	SDA S3 configuration file	Currently: $SDA_CONFIG
 	    --sda-key pathname		SDA CRYPT4GH public key file	Currently: $SDA_KEY
 
@@ -530,16 +531,13 @@ usage_general () {
 	    $myself help dataset
 
 	Environment variables:
-	    SDA_CLI     Pathname of the "sda-cli" executable.  If unset,
-	                the utility will be located using your "PATH"
-	                variable, as is done for any ordinary utility.
 
-	    MQ_CREDENTIALS, MQ_URL,
-	    MQ_EXCHANGE_PREFIX, MQ_QUEUE_PREFIX,
-	    SDA_CONFIG, SDA_KEY
-	                These variables corresponds to the similarly
-	                named global options.  The command line options
-	                will override the environment variables.
+	    MQ_CREDENTIALS, MQ_URL, MQ_EXCHANGE_PREFIX, MQ_QUEUE_PREFIX,
+	    SDA_CLI, SDA_CONFIG, SDA_KEY
+
+	        These variables corresponds to the similarly named
+	        global options.  The command line options will override
+	        the environment variables.
 
 	USAGE_GENERAL
 }
@@ -722,6 +720,9 @@ while true; do
 			;;
 		--mq-queue-prefix)
 			MQ_QUEUE_PREFIX=$2
+			;;
+		--sda-cli)
+			SDA_CLI=$2
 			;;
 		--sda-config)
 			SDA_CONFIG=$2


### PR DESCRIPTION
This PR is related to https://github.com/NBISweden/LocalEGA-SE-Deployment/issues/630 and allows a user to assign multiple accession IDs to a set of ingested files using the `sda-admin` script.

Assigning accessions to three files, giving them the IDs `MYID001`, `MYID002`, and `MYID003`:
```shell
./sda-admin accession 'MYID%03d' 1 file1 file2 file3
```

Assigning accession IDs to all files in or beneath the path `project/data`, starting at 123.  The first two accession IDs will be `PROJ00000123` and `PROJ00000124`.  The ordering in which accession IDs are assigned will depend on the ordering of the files in the RabbitMQ queue.
```shell
./sda-admin accession 'PROJ%08' 123 project/data/
```

When assigning accession IDs to multiple files, the generated IDs are outputted as shown below:
```shell
$ ./sda-admin accession 'TEST%08x' 12 tmp/
Accession ID #12: TEST0000000c
Accession ID #13: TEST0000000d
Accession ID #14: TEST0000000e
Accession ID #15: TEST0000000f
Accession ID #16: TEST00000010
Accession ID #17: TEST00000011
```

---

Additional changes:

* Make the MQ exchange and queue prefixes configurable via command-line options or environment variables, like other settings. This makes the script completely project-independent. This was requested by @dbampalikis 
* Make the path to the `sda-cli` executable configurable with a command-line option (this was only settable by an environment variable before).
* Improvements to documentation.
* Improved error reporting whenever the RabbitMQ service sends back an error response or `curl` fails for other reasons. This was requested by @dbampalikis 
* Allow the user to override the S3 access key by either setting `S3_ACCESS_KEY` in the environment or by using `--s3-access-key`.  This allows a user to do everything apart from uploading without a `s3cmd` configuration file present.  Suggested by @kostas-kou 