### PR TITLE
Add dockerhost to server cert DNS list

### DIFF
--- a/scripts/certs/ssl.cnf
+++ b/scripts/certs/ssl.cnf
@@ -91,7 +91,7 @@ subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer:always
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
-subjectAltName = DNS:localhost,DNS:mq,DNS:db,DNS:doa,DNS:download,DNS:server,DNS:oidc,IP:127.0.0.1
+subjectAltName = DNS:localhost,DNS:dockerhost,DNS:mq,DNS:db,DNS:doa,DNS:download,DNS:server,DNS:oidc,IP:127.0.0.1
 
 [ crl_ext ]
 # Extension for CRLs (`man x509v3_config`).


### PR DESCRIPTION
Adds `dockerhost` as a DNS name to the self-signed server certificate, to make it easier to access htsget from other docker containers.