### PR TITLE
hotfix: make demo-compose run as standalone

### DIFF
--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -100,6 +100,8 @@ services:
     extends:
       file: docker-compose.yml
       service: s3inbox
+    environment:
+      - SERVER_JWTPUBKEYURL=
 
 volumes:
   pgdata:
@@ -109,3 +111,5 @@ volumes:
 networks:
   public:
   secure:
+  my-app-network:
+    name: my-app-network


### PR DESCRIPTION
- s3inbox should not look for jwkurl
- add missing network dependency