### PR TITLE
include index files to demo

### DIFF
--- a/scripts/load_data.sh
+++ b/scripts/load_data.sh
@@ -7,15 +7,16 @@ pip -q install s3cmd
 
 FILES="NA12878.bam NA12878.bai NA12878_20k_b37.bam NA12878_20k_b37.bai"
 for file in ${FILES}; do
-    curl -s -L -o $file "https://github.com/ga4gh/htsget-refserver/raw/main/data/gcp/gatk-test-data/wgs_bam/$file"
+    curl -s -L -o "$file" "https://github.com/ga4gh/htsget-refserver/raw/main/data/gcp/gatk-test-data/wgs_bam/$file"
 
-    if [ "${file: -4}" = ".bai" ]; then
+    case $file in (*.bai)
         newname="$(basename "$file" .bai).bam.bai"
         mv "$file" "$newname"
         file="$newname"
-    fi
+     ;;
+    esac
 
-    yes | /shared/crypt4gh encrypt -p /shared/c4gh.pub.pem -f $file
+    yes | /shared/crypt4gh encrypt -p /shared/c4gh.pub.pem -f "$file"
     ENC_SHA=$(sha256sum "$file.c4gh" | cut -d' ' -f 1)
     ENC_MD5=$(md5sum "$file.c4gh" | cut -d' ' -f 1)
     s3cmd -q -c /shared/s3cfg put "$file.c4gh" s3://dummy_gdi.eu/"$file.c4gh"
@@ -85,9 +86,10 @@ done
 
 I=0
 for file in ${FILES}; do
-    if [ "${file: -4}" = ".bai" ]; then
+    case $file in (*.bai)
         file="$(basename "$file" .bai).bam.bai"
-    fi
+     ;;
+    esac
     I=$((I+1))
     decrypted_checksums=$(
         curl -s -u test:test \

--- a/scripts/load_data.sh
+++ b/scripts/load_data.sh
@@ -5,7 +5,8 @@ apk -q --no-cache add curl jq
 
 pip -q install s3cmd
 
-for file in NA12878.bam NA12878.bai NA12878_20k_b37.bam NA12878_20k_b37.bai; do
+FILES="NA12878.bam NA12878.bai NA12878_20k_b37.bam NA12878_20k_b37.bai"
+for file in ${FILES}; do
     curl -s -L -o $file "https://github.com/ga4gh/htsget-refserver/raw/main/data/gcp/gatk-test-data/wgs_bam/$file"
 
     if [ "${file: -4}" = ".bai" ]; then
@@ -83,7 +84,10 @@ until [ "$(curl -s -u test:test http://rabbitmq:15672/api/queues/gdi/verified | 
 done
 
 I=0
-for file in NA12878.bam NA12878.bam.bai NA12878_20k_b37.bam NA12878_20k_b37.bam.bai; do
+for file in ${FILES}; do
+    if [ "${file: -4}" = ".bai" ]; then
+        file="$(basename "$file" .bai).bam.bai"
+    fi
     I=$((I+1))
     decrypted_checksums=$(
         curl -s -u test:test \

--- a/scripts/load_data.sh
+++ b/scripts/load_data.sh
@@ -8,14 +8,10 @@ pip -q install s3cmd
 for file in NA12878.bam NA12878.bai NA12878_20k_b37.bam NA12878_20k_b37.bai; do
     curl -s -L -o $file "https://github.com/ga4gh/htsget-refserver/raw/main/data/gcp/gatk-test-data/wgs_bam/$file"
 
-    if [ "$file" = "NA12878.bai" ]; then
-        mv NA12878.bai NA12878.bam.bai
-        file="NA12878.bam.bai"
-    fi
-
-    if [ "$file" = "NA12878_20k_b37.bai" ]; then
-        mv NA12878_20k_b37.bai NA12878_20k_b37.bam.bai
-        file="NA12878_20k_b37.bam.bai"
+    if [ "${file: -4}" = ".bai" ]; then
+        newname="$(basename "$file" .bai).bam.bai"
+        mv "$file" "$newname"
+        file="$newname"
     fi
 
     yes | /shared/crypt4gh encrypt -p /shared/c4gh.pub.pem -f $file


### PR DESCRIPTION
We need the corresponding index (`.bai`) files to the two `bam` files that are loaded and ingested during the demo so that we can make range requests with `htsget-rs`. These files are renamed according to the convention that  `htsget-rs` follows.