### PR TITLE
add reencryption service

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Add the `sda-auth` client by creating a file `configuration/aai-mock/clients/cli
 client-name: "auth"
 client-id: "XC56EL11xx"
 client-secret: "wHPVQaYXmdDHg"
-redirect-uris: ["http://localhost:8085/elixir/login"]
+redirect-uris: ["http://localhost:8085/oidc/login"]
 token-endpoint-auth-method: "client_secret_basic"
 scope: ["openid", "profile", "email", "ga4gh_passport_v1", "eduperson_entitlement"]
 grant-types: ["authorization_code"]
-post-logout-redirect-uris: ["http://localhost:8085/elixir/login"]
+post-logout-redirect-uris: ["http://localhost:8085/oidc/login"]
 ```
 
 Now that everything should be configured properly, from the root folder of the `starter-kit-lsaai-mock` run:

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -2,6 +2,10 @@ app: # this is for download
   host: "0.0.0.0"
   port: "8443"
 
+auth:
+  s3inbox: "http://localhost:8000"
+  publicFile: "/shared/c4gh.pub.pem"
+
 archive:
   type: "s3"
   url: "http://s3"

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -3,7 +3,7 @@ app: # this is for download
   port: "8443"
 
 auth:
-  s3inbox: "http://localhost:8000"
+  s3Inbox: "http://localhost:8000"
   publicFile: "/shared/c4gh.pub.pem"
 
 archive:

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -104,22 +104,10 @@ services:
     volumes:
       - cacert:/etc/ssl/certs/
 
-
   reencrypt:
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
-    command: [sda-reencrypt]
-    container_name: reencrypt
-    depends_on:
-      credentials:
-        condition: service_completed_successfully
-    restart: always
-    networks:
-      - secure
-    volumes:
-      - ${CONFIG_FILEPATH}:/config.yaml
-      - ${ISS_FILEPATH}:/iss.json
-      - shared:/shared
-      - cacert:/cacert
+    extends:
+      file: docker-compose.yml
+      service: reencrypt
 
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -289,6 +289,22 @@ services:
       - ${CONFIG_FILEPATH}:/config.yaml
       - shared:/shared
 
+  reencrypt:
+    command: [sda-reencrypt]
+    container_name: reencrypt
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
+    networks:
+      - secure
+    restart: always
+    volumes:
+      - ${CONFIG_FILEPATH}:/config.yaml
+      - ${ISS_FILEPATH}:/iss.json
+      - shared:/shared
+      - cacert:/cacert
+
 volumes:
   cacert:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - OIDC_PROVIDER=http://${DOCKERHOST:-localhost}:8080/oidc/
       - OIDC_SECRET=${auth_ELIXIR_SECRET}
       - OIDC_JWKPATH=jwk
-      - OIDC_REDIRECTURL=http://localhost:8085/elixir/login
+      - OIDC_REDIRECTURL=http://localhost:8085/oidc/login
       - LOG_LEVEL=debug
       - RESIGNJWT=false
     extra_hosts:
@@ -44,6 +44,8 @@ services:
       - ${CONFIG_FILEPATH}:/config.yaml
     ports:
       - 8085:8080
+    networks:
+      - my-app-network
     restart: always
 
   rabbitmq:
@@ -313,3 +315,5 @@ volumes:
 networks:
   public:
   secure:
+  my-app-network:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,6 @@ services:
       - ${CONFIG_FILEPATH}:/config.yaml
     ports:
       - 8085:8080
-    networks:
-      - my-app-network
     restart: always
 
   rabbitmq:
@@ -314,5 +312,3 @@ volumes:
 networks:
   public:
   secure:
-  my-app-network:
-    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,25 +24,24 @@ services:
 
   auth:
     container_name: auth
+    command: sda-auth
     image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
     depends_on:
       credentials:
         condition: service_completed_successfully
     environment:
-      - ELIXIR_ID=${auth_ELIXIR_ID}
-      - ELIXIR_PROVIDER=http://${DOCKERHOST:-localhost}:8080/oidc/
-      - ELIXIR_SECRET=${auth_ELIXIR_SECRET}
-      - ELIXIR_JWKPATH=jwk
-      - ELIXIR_REDIRECTURL=http://localhost:8085/elixir/login
-      - LOG_LEVEL=info
-      - PUBLICFILE=/shared/c4gh.pub.pem
-      - RESIGNJWT=false
-      - S3INBOX=http://localhost:8000
+      - OIDC_ID=${auth_ELIXIR_ID}
+      - OIDC_PROVIDER=http://${DOCKERHOST:-localhost}:8080/oidc/
+      - OIDC_SECRET=${auth_ELIXIR_SECRET}
+      - OIDC_JWKPATH=jwk
+      - OIDC_REDIRECTURL=http://localhost:8085/elixir/login
       - LOG_LEVEL=debug
+      - RESIGNJWT=false
     extra_hosts:
       - ${DOCKERHOST:-localhost}:host-gateway
     volumes:
       - shared:/shared
+      - ${CONFIG_FILEPATH}:/config.yaml
     ports:
       - 8085:8080
     restart: always
@@ -290,7 +289,7 @@ services:
       - shared:/shared
 
   reencrypt:
-    command: [sda-reencrypt]
+    command: sda-reencrypt
     container_name: reencrypt
     depends_on:
       credentials:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,7 +302,6 @@ services:
     restart: always
     volumes:
       - ${CONFIG_FILEPATH}:/config.yaml
-      - ${ISS_FILEPATH}:/iss.json
       - shared:/shared
       - cacert:/cacert
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
   auth:
     container_name: auth
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25-auth
+    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
     depends_on:
       credentials:
         condition: service_completed_successfully


### PR DESCRIPTION
This PR closes #49 .

- adds the re-encryption service to the main docker file
- fixes the image name of `auth` and its configs