### PR TITLE
connect auth to db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,13 @@ services:
     container_name: auth
     command: sda-auth
     image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
+    networks:
+      - secure
     depends_on:
       credentials:
         condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
     environment:
       - OIDC_ID=${auth_ELIXIR_ID}
       - OIDC_PROVIDER=http://${DOCKERHOST:-localhost}:8080/oidc/
@@ -37,6 +41,8 @@ services:
       - OIDC_REDIRECTURL=http://localhost:8085/oidc/login
       - LOG_LEVEL=debug
       - RESIGNJWT=false
+      - DB_PASSWORD=${auth_DB_PASSWORD}
+      - DB_USER=${auth_DB_USER}
     extra_hosts:
       - ${DOCKERHOST:-localhost}:host-gateway
     volumes:

--- a/scripts/make_credentials.sh
+++ b/scripts/make_credentials.sh
@@ -10,7 +10,7 @@ apt-get -o DPkg::Lock::Timeout=60 install -y curl jq postgresql-client openssl >
 pip install --upgrade pip > /dev/null
 pip install aiohttp Authlib joserfc requests > /dev/null
 
-for n in download finalize inbox ingest mapper sync verify; do
+for n in api auth download finalize inbox ingest mapper sync verify; do
     echo "creating credentials for: $n"
     ## password and permissions for MQ
     body_data=$(jq -n -c --arg password "$n" --arg tags none '$ARGS.named')


### PR DESCRIPTION
Adds the db role `auth`, from https://github.com/neicnordic/sensitive-data-archive/pull/1099 and makes sure that the auth service can connect to the db.
Also adds the db role `api`, from https://github.com/neicnordic/sensitive-data-archive/pull/1084