### PR TITLE
change host for auth to be accessible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - RESIGNJWT=false
     extra_hosts:
       - ${DOCKERHOST:-localhost}:host-gateway
+      - "host.docker.internal:host-gateway"
     volumes:
       - shared:/shared
       - ${CONFIG_FILEPATH}:/config.yaml


### PR DESCRIPTION
This one-liner seemed to fix the accessibility of auth from the host. Leaving the already existing line above in case it is still relevant for docker running on other types of OS.