### PR TITLE
Fix: make_credentials.sh uses passwords set in the .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,8 +63,8 @@ verify_DB_USER=verify
 verify_SCHEMA_TYPE=federated
 
 # s3inbox
-s3inbox_BROKER_PASSWORD=inbox
-s3inbox_BROKER_ROUTINGKEY=inbox
-s3inbox_BROKER_USER=inbox
-s3inbox_DB_PASSWORD=inbox
-s3inbox_DB_USER=inbox
+inbox_BROKER_PASSWORD=inbox
+inbox_BROKER_ROUTINGKEY=inbox
+inbox_BROKER_USER=inbox
+inbox_DB_PASSWORD=inbox
+inbox_DB_USER=inbox

--- a/.github/workflows/test_demo.yaml
+++ b/.github/workflows/test_demo.yaml
@@ -16,6 +16,7 @@ jobs:
           cp config/config.yaml.example config/config.yaml
           cp config/iss.json.example config/iss.json
           cp .env.example .env
+          sed -E -i  's/(_DB_PASSWORD=)([^ ]+)/\1\2New/;s/(_BROKER_PASSWORD=)([^ ]+)/\1\2New/ ' .env
           docker compose -f docker-compose-demo.yml up -d
           until [ "$(docker inspect data_loader  --format='{{.State.Status}}')" = "exited" ]; do
             echo "waithg for data_loader to finish"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
         condition: service_healthy
     environment:
       - PGPASSWORD=${credentials_PGPASSWORD}
+    env_file:
+      - .env
     image: python:3.10-slim
     networks:
       - secure
@@ -270,11 +272,11 @@ services:
       s3:
         condition: service_healthy
     environment:
-      - BROKER_PASSWORD=${s3inbox_BROKER_PASSWORD}
-      - BROKER_ROUTINGKEY=${s3inbox_BROKER_ROUTINGKEY}
-      - BROKER_USER=${s3inbox_BROKER_USER}
-      - DB_PASSWORD=${s3inbox_DB_PASSWORD}
-      - DB_USER=${s3inbox_DB_USER}
+      - BROKER_PASSWORD=${inbox_BROKER_PASSWORD}
+      - BROKER_ROUTINGKEY=${inbox_BROKER_ROUTINGKEY}
+      - BROKER_USER=${inbox_BROKER_USER}
+      - DB_PASSWORD=${inbox_DB_PASSWORD}
+      - DB_USER=${inbox_DB_USER}
       - SERVER_JWTPUBKEYURL=http://${DOCKERHOST:-dockerhost}:8080/oidc/jwk
     extra_hosts:
       - ${DOCKERHOST:-dockerhost}:host-gateway

--- a/scripts/make_credentials.sh
+++ b/scripts/make_credentials.sh
@@ -17,7 +17,6 @@ for n in download finalize inbox ingest mapper sync verify; do
     db_password=${db_password:-$n}
     mq_password=${mq_password:-$n}
 
-    echo "role: $n, db password: $db_password, mq password: $mq_password"
     ## setting passwords and permissions for MQ
     body_data=$(jq -n -c --arg password "$mq_password" --arg tags none '$ARGS.named')
     curl -s -u test:test -X PUT "http://rabbitmq:15672/api/users/$n" -H "content-type:application/json" -d "${body_data}"


### PR DESCRIPTION
This PR closes #52 

**How to test**
- Copy the file `.env.example` to  `.env`
- Modify some or all of the ENVs for `*_BROKER_PASSWORD` and `*_DB_PASSWORD`
- Start the docker setup by 
```
docker compose -f docker-compose-demo.yml up -d 
```
- Check if the docker setup runs properly and if the following commands returns meaningful results and the file `htsnexus_test_NA12878.bam` is downloaded
```
token=$(curl -s -k https://localhost:8080/tokens | jq -r '.[0]')
curl -s -H "Authorization: Bearer $token" http://localhost:8443/metadata/datasets | jq .
datasetID=DATASET0001
filename="htsnexus_test_NA12878.bam"
curl -s -H "Authorization: Bearer $token" http://localhost:8443/metadata/datasets/$datasetID/files  
curl -s -H "Authorization: Bearer $token" http://localhost:8443/s3/$datasetID/$filename -o "$filename"
```