### PR TITLE
add db user auth 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ credentials_PGPASSWORD=rootpass
 # auth
 auth_ELIXIR_ID=XC56EL11xx
 auth_ELIXIR_SECRET=wHPVQaYXmdDHg
+auth_DB_PASSWORD=auth
+auth_DB_USER=auth
 
 # rabbitmq
 rabbitmq_MQ_PASSWORD=test

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -12,6 +12,8 @@ services:
     depends_on:
       s3inbox:
         condition: service_started
+      oidc:
+        condition: service_healthy
     image: python:3.10-alpine
     networks:
       - secure
@@ -41,6 +43,7 @@ services:
     image: python:3.10-slim
     networks:
       - public
+      - secure
     ports:
       - "8080:8080"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,6 @@ services:
       - DB_PASSWORD=${download_DB_PASSWORD}
       - DB_USER=${download_DB_USER}
       - OIDC_CONFIGURATION_URL=http://${DOCKERHOST:-dockerhost}:8080/oidc/.well-known/openid-configuration
-      - ARCHIVE_TYPE=s3seekable
     extra_hosts:
       - ${DOCKERHOST:-dockerhost}:host-gateway
     image: harbor.nbis.se/gdi/sda-download:20240415

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,13 @@ services:
     container_name: auth
     command: sda-auth
     image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
+    networks:
+      - secure
     depends_on:
       credentials:
         condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
     environment:
       - OIDC_ID=${auth_ELIXIR_ID}
       - OIDC_PROVIDER=http://${DOCKERHOST:-localhost}:8080/oidc/
@@ -39,6 +43,8 @@ services:
       - OIDC_REDIRECTURL=http://localhost:8085/oidc/login
       - LOG_LEVEL=debug
       - RESIGNJWT=false
+      - DB_PASSWORD=${auth_DB_PASSWORD}
+      - DB_USER=${auth_DB_USER}
     extra_hosts:
       - ${DOCKERHOST:-localhost}:host-gateway
       - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
   auth:
     container_name: auth
     command: sda-auth
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR1099
     networks:
       - secure
     depends_on:
@@ -71,7 +71,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 20
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25-rabbitmq
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR1099-rabbitmq
     networks:
       - secure
     ports:
@@ -95,7 +95,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 20
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25-postgres
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR1099-postgres
     networks:
       - secure
     restart: always
@@ -147,7 +147,7 @@ services:
       - OIDC_CONFIGURATION_URL=http://${DOCKERHOST:-dockerhost}:8080/oidc/.well-known/openid-configuration
     extra_hosts:
       - ${DOCKERHOST:-dockerhost}:host-gateway
-    image: harbor.nbis.se/gdi/sda-download:20240415
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR1099-download
     networks:
       - public
       - secure
@@ -178,7 +178,7 @@ services:
       - BROKER_USER=${finalize_BROKER_USER}
       - DB_PASSWORD=${finalize_DB_PASSWORD}
       - DB_USER=${finalize_DB_USER}
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR1099
     networks:
       - secure
     restart: always
@@ -204,7 +204,7 @@ services:
       - BROKER_USER=${ingest_BROKER_USER}
       - DB_PASSWORD=${ingest_DB_PASSWORD}
       - DB_USER=${ingest_DB_USER}
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR1099
     networks:
       - secure
     restart: always
@@ -230,7 +230,7 @@ services:
       - BROKER_USER=${mapper_BROKER_USER}
       - DB_PASSWORD=${mapper_DB_PASSWORD}
       - DB_USER=${mapper_DB_USER}
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR1099
     networks:
       - secure
     restart: always
@@ -256,7 +256,7 @@ services:
       - BROKER_USER=${verify_BROKER_USER}
       - DB_PASSWORD=${verify_DB_PASSWORD}
       - DB_USER=${verify_DB_USER}
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR1099
     networks:
       - secure
     restart: always
@@ -285,7 +285,7 @@ services:
       - SERVER_JWTPUBKEYURL=http://${DOCKERHOST:-dockerhost}:8080/oidc/jwk
     extra_hosts:
       - ${DOCKERHOST:-dockerhost}:host-gateway
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR1099
     networks:
       - public
       - secure
@@ -302,7 +302,7 @@ services:
     depends_on:
       credentials:
         condition: service_completed_successfully
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.25
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR1099
     networks:
       - secure
     restart: always

--- a/scripts/make_credentials.sh
+++ b/scripts/make_credentials.sh
@@ -10,7 +10,7 @@ apt-get -o DPkg::Lock::Timeout=60 install -y curl jq postgresql-client openssl >
 pip install --upgrade pip > /dev/null
 pip install aiohttp Authlib joserfc requests > /dev/null
 
-for n in download finalize inbox ingest mapper sync verify; do
+for n in api auth download finalize inbox ingest mapper sync verify; do
     echo "creating credentials for: $n"
     db_password=$(eval echo \$$n"_DB_PASSWORD")
     mq_password=$(eval echo \$$n"_BROKER_PASSWORD")


### PR DESCRIPTION
- Adds the db role `auth`, from https://github.com/neicnordic/sensitive-data-archive/pull/1099 and makes sure that the auth service can connect to the db.
- Also adds the db role `api`, from https://github.com/neicnordic/sensitive-data-archive/pull/1084
- data_loader script inserts the key hash into the db before uploading files, so that ingestion won't crash

Depends on a new version of sda postgres (this `ghcr.io/neicnordic/sensitive-data-archive:PR1099-postgres` or newer). This PR will be undrafted when there are new sda images (non PR images) to refer to.