### PR TITLE
Update sda stack version which supports latest version of htsget-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ Detailed documentation on the `sda-pipeline` can be found at: [https://neic-sda.
 
 NeIC Sensitive Data Archive documentation can be found at: [https://neic-sda.readthedocs.io/en/latest/](https://neic-sda.readthedocs.io/en/latest/) .
 
-> [!IMPORTANT]  
-> The current version of the `sda-pipeline` does not support the [starter-kit-htsget](https://github.com/GenomicDataInfrastructure/starter-kit-htsget) for the moment.
-> 
-> For the [starter-kit-htsget](https://github.com/GenomicDataInfrastructure/starter-kit-htsget) to function an earlier version of the `download` service needs to be deployed until further notice. 
-
 ## Deployment
 
 There exist two docker compose files at the root of the repo.

--- a/config/TLS-example/docker-compose.yml
+++ b/config/TLS-example/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   auth:
     container_name: auth
     command: sda-auth
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - public
     ports:
@@ -32,7 +32,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 20
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14-rabbitmq
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41-rabbitmq
     networks:
       - secure
     ports:
@@ -64,7 +64,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 20
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14-postgres
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41-postgres
     networks:
       - secure
     restart: always
@@ -81,7 +81,7 @@ services:
     environment:
       - DB_PASSWORD=${download_DB_PASSWORD}
       - DB_USER=download
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14-download
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41-download
     networks:
       - public
       - secure
@@ -110,7 +110,7 @@ services:
       - BROKER_USER=finalize
       - DB_PASSWORD=${finalize_DB_PASSWORD}
       - DB_USER=finalize
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - secure
     restart: always
@@ -133,7 +133,7 @@ services:
       - BROKER_USER=ingest
       - DB_PASSWORD=${ingest_DB_PASSWORD}
       - DB_USER=ingest
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - secure
     restart: always
@@ -156,7 +156,7 @@ services:
       - BROKER_USER=mapper
       - DB_PASSWORD=${mapper_DB_PASSWORD}
       - DB_USER=mapper
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - secure
     restart: always
@@ -179,7 +179,7 @@ services:
       - BROKER_USER=verify
       - DB_PASSWORD=${verify_DB_PASSWORD}
       - DB_USER=verify
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - secure
     restart: always
@@ -202,7 +202,7 @@ services:
       - BROKER_USER=inbox
       - DB_PASSWORD=${s3inbox_DB_PASSWORD}
       - DB_USER=inbox
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - public
       - secure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
   auth:
     container_name: auth
     command: sda-auth
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     depends_on:
       credentials:
         condition: service_completed_successfully
@@ -65,7 +65,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 20
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14-rabbitmq
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41-rabbitmq
     networks:
       - secure
     ports:
@@ -89,7 +89,9 @@ services:
       interval: 5s
       timeout: 20s
       retries: 20
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14-postgres
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41-postgres
+    extra_hosts:
+      - ${DOCKERHOST:-dockerhost}:host-gateway
     networks:
       - secure
     restart: always
@@ -141,7 +143,7 @@ services:
       - OIDC_CONFIGURATION_URL=http://${DOCKERHOST:-dockerhost}:8080/oidc/.well-known/openid-configuration
     extra_hosts:
       - ${DOCKERHOST:-dockerhost}:host-gateway
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14-download
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41-download
     networks:
       - public
       - secure
@@ -172,7 +174,7 @@ services:
       - BROKER_USER=${finalize_BROKER_USER}
       - DB_PASSWORD=${finalize_DB_PASSWORD}
       - DB_USER=${finalize_DB_USER}
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - secure
     restart: always
@@ -198,7 +200,7 @@ services:
       - BROKER_USER=${ingest_BROKER_USER}
       - DB_PASSWORD=${ingest_DB_PASSWORD}
       - DB_USER=${ingest_DB_USER}
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - secure
     restart: always
@@ -224,7 +226,7 @@ services:
       - BROKER_USER=${mapper_BROKER_USER}
       - DB_PASSWORD=${mapper_DB_PASSWORD}
       - DB_USER=${mapper_DB_USER}
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - secure
     restart: always
@@ -250,7 +252,7 @@ services:
       - BROKER_USER=${verify_BROKER_USER}
       - DB_PASSWORD=${verify_DB_PASSWORD}
       - DB_USER=${verify_DB_USER}
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - secure
     restart: always
@@ -279,7 +281,7 @@ services:
       - SERVER_JWTPUBKEYURL=http://${DOCKERHOST:-dockerhost}:8080/oidc/jwk
     extra_hosts:
       - ${DOCKERHOST:-dockerhost}:host-gateway
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - public
       - secure
@@ -296,7 +298,7 @@ services:
     depends_on:
       credentials:
         condition: service_completed_successfully
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.14
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.0.41
     networks:
       - secure
     restart: always


### PR DESCRIPTION
Update version of sda stack to v3.0.41 which supports latest version of htsget-rs, and update README.md to remove note about htsget-rs being unsupported